### PR TITLE
Remove external reverter link

### DIFF
--- a/notifiers/slack.py
+++ b/notifiers/slack.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import urllib.parse
 from collections.abc import Callable
 
 import requests
@@ -170,55 +169,6 @@ def _upload_node_images(
             log.debug("Failed to upload drag image for node %s", node_id, exc_info=True)
 
 
-def _post_reverter_link(
-    bot_token: str, channel_id: str, drags: list[dict], changeset: str,
-    thread_ts: str | None = None,
-) -> None:
-    """Post a link to the OSM reverter as a threaded reply."""
-    if not thread_ts:
-        return
-
-    # Collect affected node and way IDs
-    node_ids: set[str] = set()
-    way_ids: set[str] = set()
-    for drag in drags:
-        node_ids.add(drag["node_id"])
-        way_ids.add(drag["way_id"])
-
-    query_parts = [f"n{nid}" for nid in sorted(node_ids)] + [f"w{wid}" for wid in sorted(way_ids)]
-    query_filter = ",".join(query_parts)
-
-    node_links = ", ".join(
-        f"https://www.openstreetmap.org/node/{nid}" for nid in sorted(node_ids)
-    )
-    node_word = "node" if len(node_ids) == 1 else "nodes"
-    was_were = "was" if len(node_ids) == 1 else "were"
-    discussion = (
-        f"Hello! I noticed that {node_word} {node_links} {was_were} moved "
-        f"a long distance in this changeset. This is a common mistake "
-        f"that happens when you click on a point and drag to move the map. "
-        f"The point moves with your mouse instead of the map.\n\n"
-        f"I moved things back to where they were before, so no harm done!\n\n"
-        f"To avoid this in the future:\n"
-        f"- Try to click on an empty part of the map when you want to "
-        f"move around\n"
-        f"- If you see a point move by mistake, press Ctrl+Z (or Cmd+Z "
-        f"on Mac) to undo it\n\n"
-        f"Happy mapping!"
-    )
-
-    params = urllib.parse.urlencode({
-        "changesets": changeset,
-        "query-filter": query_filter,
-        "comment": f"Revert accidental node drag from changeset {changeset}",
-        "discussion": discussion,
-    })
-
-    reverter_url = f"https://revert.monicz.dev/?{params}"
-    text = f"<{reverter_url}|:leftwards_arrow_with_hook: Open in Reverter>"
-
-    _post_slack_message(bot_token, channel_id, text, thread_ts=thread_ts)
-
 
 def _post_slack_message(
     bot_token: str, channel_id: str, text: str, blocks: list[dict] | None = None,
@@ -261,7 +211,7 @@ def send_slack_interactive(bot_token: str, channel_id: str, drags: list[dict]) -
         text, blocks = build_drag_blocks(cs_drags, changeset, user)
         ts = _post_slack_message(bot_token, channel_id, text, blocks)
         _upload_node_images(bot_token, channel_id, cs_drags, ts)
-        _post_reverter_link(bot_token, channel_id, cs_drags, changeset, ts)
+
 
 
 def handle_revert_action(ack: Callable, body: dict, client: object, osm_token: str,
@@ -392,7 +342,7 @@ def send_slack_summary(bot_token: str, channel_id: str, drags: list[dict], inter
         text = _format_drag_text(cs_drags, changeset, user)
         ts = _post_slack_message(bot_token, channel_id, text)
         _upload_node_images(bot_token, channel_id, cs_drags, ts)
-        _post_reverter_link(bot_token, channel_id, cs_drags, changeset, ts)
+
 
 
 def _format_tag_issue_text(issues: list[Issue], changeset: str, user: str) -> str:

--- a/notifiers/slack.py
+++ b/notifiers/slack.py
@@ -169,7 +169,6 @@ def _upload_node_images(
             log.debug("Failed to upload drag image for node %s", node_id, exc_info=True)
 
 
-
 def _post_slack_message(
     bot_token: str, channel_id: str, text: str, blocks: list[dict] | None = None,
     thread_ts: str | None = None,
@@ -211,7 +210,6 @@ def send_slack_interactive(bot_token: str, channel_id: str, drags: list[dict]) -
         text, blocks = build_drag_blocks(cs_drags, changeset, user)
         ts = _post_slack_message(bot_token, channel_id, text, blocks)
         _upload_node_images(bot_token, channel_id, cs_drags, ts)
-
 
 
 def handle_revert_action(ack: Callable, body: dict, client: object, osm_token: str,
@@ -342,7 +340,6 @@ def send_slack_summary(bot_token: str, channel_id: str, drags: list[dict], inter
         text = _format_drag_text(cs_drags, changeset, user)
         ts = _post_slack_message(bot_token, channel_id, text)
         _upload_node_images(bot_token, channel_id, cs_drags, ts)
-
 
 
 def _format_tag_issue_text(issues: list[Issue], changeset: str, user: str) -> str:

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -73,8 +73,8 @@ def test_multiple_changesets():
     ]
     with patch("notifiers.slack.requests.post", return_value=_mock_post_ok()) as mock_post:
         send_slack_summary("xoxb-test", "C123", drags)
-        # 2 summaries + 2 reverter links = 4 calls
-        assert mock_post.call_count == 4
+        # 2 summaries = 2 calls
+        assert mock_post.call_count == 2
 
 
 def test_substitution_node_links_to_new():
@@ -116,40 +116,23 @@ def test_interactive_delegates_to_send_slack_interactive():
         mock_interactive.assert_called_once_with("xoxb-test", "C123", drags)
 
 
-def test_non_interactive_posts_summary_and_reverter():
-    """Non-interactive mode posts summary then reverter link as thread."""
+def test_non_interactive_posts_summary():
+    """Non-interactive mode posts summary message."""
     drags = [_make_drag()]
     with patch("notifiers.slack.requests.post", return_value=_mock_post_ok()) as mock_post:
         send_slack_summary("xoxb-test", "C123", drags)
-        # First call: summary, second call: reverter link
-        assert mock_post.call_count == 2
+        assert mock_post.call_count == 1
         assert "chat.postMessage" in mock_post.call_args_list[0][0][0]
-        assert "chat.postMessage" in mock_post.call_args_list[1][0][0]
-        # Reverter link should be threaded
-        assert mock_post.call_args_list[1][1]["json"]["thread_ts"] == "111.222"
 
 
-def test_reverter_link_contains_query_params():
-    """Reverter link includes changesets, query-filter, comment, discussion."""
-    drags = [_make_drag()]
-    with patch("notifiers.slack.requests.post", return_value=_mock_post_ok()) as mock_post:
-        send_slack_summary("xoxb-test", "C123", drags)
-        reverter_text = mock_post.call_args_list[1][1]["json"]["text"]
-        assert "revert.monicz.dev" in reverter_text
-        assert "changesets=999" in reverter_text
-        assert "n42" in reverter_text
-        assert "w111" in reverter_text
-
-
-def test_send_slack_interactive_posts_blocks_and_reverter():
-    """send_slack_interactive posts blocks then reverter link."""
+def test_send_slack_interactive_posts_blocks():
+    """send_slack_interactive posts blocks with actions."""
     drags = [_make_drag()]
 
     with patch("notifiers.slack.requests.post", return_value=_mock_post_ok()) as mock_post:
         with patch("notifiers.slack.generate_drag_image", return_value=None):
             send_slack_interactive("xoxb-test", "C123", drags)
 
-    # First call: summary with blocks, second: reverter link
     first_call = mock_post.call_args_list[0]
     assert "chat.postMessage" in first_call[0][0]
     payload = first_call[1]["json"]


### PR DESCRIPTION
## Summary
- Remove `_post_reverter_link` function and its calls from both interactive and non-interactive Slack notification flows
- The external reverter (revert.monicz.dev) links had broken Overpass filtering, making them non-functional
- Clean up unused `urllib.parse` import and update tests

## Test plan
- [x] All existing tests updated and passing (128 passed)