### PR TITLE
Build changeset comment from actually-reverted node IDs

### DIFF
--- a/notifiers/slack.py
+++ b/notifiers/slack.py
@@ -228,36 +228,43 @@ def handle_revert_action(ack: Callable, body: dict, client: object, osm_token: s
     ts = body["message"]["ts"]
 
     comment = f"Revert accidental node drag from changeset {original_changeset}"
-    node_links = ", ".join(
-        f"https://www.openstreetmap.org/node/{nid}" for nid in sorted(node_ids)
-    )
-    node_word = "node" if len(node_ids) == 1 else "nodes"
-    was_were = "was" if len(node_ids) == 1 else "were"
-    changeset_comment = (
-        f"Hello! I noticed that {node_word} {node_links} {was_were} moved "
-        f"a long distance in this changeset. This is a common mistake "
-        f"that happens when you click on a point and drag to move the map. "
-        f"The point moves with your mouse instead of the map.\n\n"
-        f"I moved things back to where they were before in "
-        f"https://www.openstreetmap.org/changeset/{{revert_changeset_id}}"
-        f", so no harm done!\n\n"
-        f"To avoid this in the future:\n"
-        f"- Try to click on an empty part of the map when you want to "
-        f"move around\n"
-        f"- If you see a point move by mistake, press Ctrl+Z (or Cmd+Z "
-        f"on Mac) to undo it\n\n"
-        f"Happy mapping!"
-    )
 
     try:
         result = revert_mod.revert_changeset(
             osm_token, original_changeset, comment,
             node_ids=node_ids,
             way_ids=way_ids,
-            changeset_comment=changeset_comment,
             api_base=api_base,
         )
         cs_id = result.revert_changeset_id
+
+        # Comment on the original changeset with the actually-reverted node IDs
+        reverted_nodes = result.nodes_moved + result.nodes_undeleted
+        if reverted_nodes:
+            node_links = ", ".join(
+                f"https://www.openstreetmap.org/node/{nid}"
+                for nid in sorted(reverted_nodes)
+            )
+            node_word = "node" if len(reverted_nodes) == 1 else "nodes"
+            was_were = "was" if len(reverted_nodes) == 1 else "were"
+            changeset_comment = (
+                f"Hello! I noticed that {node_word} {node_links} {was_were} moved "
+                f"a long distance in this changeset. This is a common mistake "
+                f"that happens when you click on a point and drag to move the map. "
+                f"The point moves with your mouse instead of the map.\n\n"
+                f"I moved things back to where they were before in "
+                f"https://www.openstreetmap.org/changeset/{cs_id}"
+                f", so no harm done!\n\n"
+                f"To avoid this in the future:\n"
+                f"- Try to click on an empty part of the map when you want to "
+                f"move around\n"
+                f"- If you see a point move by mistake, press Ctrl+Z (or Cmd+Z "
+                f"on Mac) to undo it\n\n"
+                f"Happy mapping!"
+            )
+            revert_mod.comment_on_changeset(
+                osm_token, original_changeset, changeset_comment, api_base=api_base,
+            )
 
         # Update the message: remove buttons, add confirmation
         original_blocks = body["message"].get("blocks", [])

--- a/revert.py
+++ b/revert.py
@@ -415,8 +415,6 @@ def revert_changeset(
 
     # -- Comment on original changeset -----------------------------------------
     if changeset_comment:
-        # Allow {revert_changeset_id} placeholder in the comment template
-        final_comment = changeset_comment.format(revert_changeset_id=cs_id)
-        comment_on_changeset(osm_token, changeset_id, final_comment, api_base=api_base)
+        comment_on_changeset(osm_token, changeset_id, changeset_comment, api_base=api_base)
 
     return result

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,5 +1,8 @@
+import json
 from unittest.mock import patch, MagicMock
-from notifiers.slack import send_slack_summary, send_slack_interactive
+
+from notifiers.slack import send_slack_summary, send_slack_interactive, handle_revert_action
+from revert import RevertResult
 
 
 def _mock_post_ok():
@@ -139,3 +142,52 @@ def test_send_slack_interactive_posts_blocks():
     assert payload["channel"] == "C123"
     assert "blocks" in payload
     assert any(b["type"] == "actions" for b in payload["blocks"])
+
+
+def _make_revert_body(node_ids, way_ids, changeset):
+    """Build a minimal Slack action body for handle_revert_action."""
+    return {
+        "actions": [{
+            "value": json.dumps({
+                "node_ids": node_ids,
+                "way_ids": way_ids,
+                "changeset": changeset,
+            }),
+        }],
+        "user": {"username": "testuser"},
+        "channel": {"id": "C123"},
+        "message": {"ts": "111.222", "blocks": []},
+    }
+
+
+def test_revert_comment_uses_actually_reverted_nodes():
+    """Changeset comment should only mention nodes that were actually reverted,
+    not all node IDs from the drag detection."""
+    # Button has 3 node IDs, but only node 42 was actually moved
+    body = _make_revert_body(
+        node_ids=["42", "99", "100"],
+        way_ids=["111"],
+        changeset="999",
+    )
+
+    result = RevertResult(
+        revert_changeset_id="5555",
+        nodes_moved=["42"],
+        nodes_undeleted=[],
+        ways_updated=["111"],
+    )
+
+    mock_ack = MagicMock()
+    mock_client = MagicMock()
+
+    with patch("notifiers.slack.revert_mod.revert_changeset", return_value=result):
+        with patch("notifiers.slack.revert_mod.comment_on_changeset") as mock_comment:
+            handle_revert_action(mock_ack, body, mock_client, "fake-token")
+
+            mock_comment.assert_called_once()
+            comment_text = mock_comment.call_args[0][2]
+            assert "node/42" in comment_text
+            assert "node/99" not in comment_text
+            assert "node/100" not in comment_text
+            # Should use singular "node" since only one was reverted
+            assert "node https://" in comment_text


### PR DESCRIPTION
## Summary
- The changeset comment previously listed node IDs from the drag detection, which could include nodes not actually modified in the changeset (e.g. substitution references or nodes moved by a different changeset in the same augmented diff window)
- Now builds the comment after the revert completes, using `result.nodes_moved` and `result.nodes_undeleted` to only mention nodes that were actually reverted
- Also uses the revert changeset ID directly instead of a template placeholder, since the comment is now built after the revert

## Test plan
- [x] Added test verifying comment only mentions actually-reverted nodes, not all detected node IDs
- [x] All 129 tests passing